### PR TITLE
Bugfix typeerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is *NOT* the project web page.
 This implementation is built on top of https://github.com/fizyr/keras-retinanet.
 The SKU110K dataset is provided in csv format compatible with the code CSV parser.
 
-Dependencies include: 'keras', 'keras-resnet', 'six', 'scipy'. 'Pillow', 'pandas', 'tensorflow-gpu'
+Dependencies include: 'keras', 'keras-resnet', 'six', 'scipy'. 'Pillow', 'pandas', 'tensorflow-gpu', 'tqdm'
 This repository requires Keras 2.2.4 or higher, and was tested using Python 2.7.6 and OpenCV 3.1.
 
 The output files will be saved under "$HOME"/Documents/SKU110K and have the same structure as in https://github.com/fizyr/keras-retinanet:

--- a/object_detector_retinanet/keras_retinanet/preprocessing/csv_generator.py
+++ b/object_detector_retinanet/keras_retinanet/preprocessing/csv_generator.py
@@ -21,6 +21,7 @@ import cv2
 import numpy as np
 from PIL import Image
 from six import raise_from
+from tqdm import tqdm
 
 import csv
 import sys
@@ -69,7 +70,8 @@ def _read_images(base_dir):
     for project in dirs:
         project_imgs = os.listdir(os.path.join(base_dir, project))
         i = 0
-        for image in project_imgs:
+        print("Loading images...")
+        for image in tqdm(project_imgs):
             try:
                 img_file = os.path.join(base_dir, project, image)
                 # Check images exists

--- a/object_detector_retinanet/keras_retinanet/preprocessing/csv_generator.py
+++ b/object_detector_retinanet/keras_retinanet/preprocessing/csv_generator.py
@@ -103,6 +103,12 @@ def _read_annotations(csv_reader, classes, base_dir, image_existence):
 
         try:
             img_file, x1, y1, x2, y2, class_name, width, height = row[:]
+            x1 = int(x1)
+            x2 = int(x2)
+            y1 = int(y1)
+            y2 = int(y2)
+            width = int(width)
+            height = int(height)
 
             # x1 < 0 | y1 < 0 | x2 <= 0 | y2 <= 0
             if x1 < 0 or y1 < 0 or x2 <= 0 or y2 <= 0:


### PR DESCRIPTION
The error raised (see. issue #2) comes from the fact that annotation coordinates are read from a file, hence they are typed as str. When compared with an int value, the TypeError is raised since it is not allowed to compare int and str with comparison operators. A cast from str to int solves the problem.