### PR TITLE
Bugfix TypeError

### DIFF
--- a/object_detector_retinanet/keras_retinanet/bin/train.py
+++ b/object_detector_retinanet/keras_retinanet/bin/train.py
@@ -294,12 +294,12 @@ def parse_args(args):
     oid_parser.add_argument('--fixed-labels', help='Use the exact specified labels.', default=False)
 
     data_dir = annotation_path()
-    args_annotations = data_dir + '/annotations_train.csv'
-    args_classes = data_dir + '/class_mappings_train.csv'
-    args_val_annotations = data_dir + '/annotations_val.csv'
+    args_annotations = os.path.join(data_dir, '/annotations_train.csv')
+    args_classes = os.path.join(data_dir, '/class_mappings_train.csv')
+    args_val_annotations = os.path.join(data_dir, '/annotations_val.csv')
 
-    args_snapshot_path = root_dir() + '/snapshot'
-    args_tensorboard_dir = root_dir() + '/logs'
+    args_snapshot_path = os.path.join(root_dir(), '/snapshot')
+    args_tensorboard_dir = os.path.join(root_dir(), '/logs')
 
     csv_parser = subparsers.add_parser('csv')
     csv_parser.add_argument('--annotations', help='Path to CSV file containing annotations for training.',
@@ -380,7 +380,7 @@ def main(args=None):
     keras.backend.tensorflow_backend.set_session(get_session())
 
     # Weights and logs saves in a new locations
-    stmp = time.strftime("%c").replace(" ", "_")
+    stmp = time.strftime("%c").replace(":", "_").replace(" ", "_")
     args.snapshot_path = os.path.join(args.snapshot_path, stmp)
     args.tensorboard_dir = os.path.join(args.tensorboard_dir, stmp)
     print("Weights will be saved in  {}".format(args.snapshot_path))

--- a/object_detector_retinanet/utils.py
+++ b/object_detector_retinanet/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import platform
 
 __author__ = 'roeiherz'
 
@@ -38,7 +39,10 @@ def create_folder(path):
 
 
 def root_dir():
-    return os.path.join(os.getenv("HOME"), 'Documents', 'SKU110K')
+    if platform.system() == 'Linux':
+        return os.path.join(os.getenv('HOME'), 'Documents', 'SKU110K')
+    elif platform.system() == 'Windows':
+        return os.path.abspath('C:/Users/{}/Documents/SKU110K/'.format(os.getenv('username')))
 
 
 def image_path():


### PR DESCRIPTION
The error raised (see issue #5) come from the fact that ``os.getenv("HOME")`` returns null on Windows. This can be solved by generating platform based ``root_dir()`` return statements. 

After this fix errors were raised when paths are made by concatinating strings instead of using ``os.path.join()`` and when paths contain a colon. The colon is used to signify disks on Windows, thus timestamping using the colon so separate hours, minutes and seconds results in errors on Windows. To solve this ``os.path.join()`` should be used to expand a path and colons should be replaced by the underscore. 